### PR TITLE
Refactor/#6

### DIFF
--- a/src/Hooks/useScrollFadeIn.ts
+++ b/src/Hooks/useScrollFadeIn.ts
@@ -1,45 +1,49 @@
-import { useRef, useEffect, useCallback } from 'react'
+import React, { useRef, useEffect, useCallback } from 'react'
 
-export default function useScrollFadeIn(
-  direction: 'up' | 'down' | 'left' | 'right',
+type ScrollDirection = 'up' | 'down' | 'left' | 'right' | 'center'
+
+export default function useScrollFadeIn<T extends HTMLElement>(
+  direction: ScrollDirection,
   duration: number,
   delay: number
 ): {
-  ref: React.RefObject<any>
+  ref: React.RefObject<T>
   style: React.CSSProperties
 } {
-  const element = useRef()
-  const handleDirection = (name: string): string | undefined => {
+  const element = useRef<T>(null)
+  const handleDirection = (name: ScrollDirection): string | undefined => {
     switch (name) {
       case 'up':
-        return 'translate3d(0, 50%, 0)'
+        return 'translate3d(0, 30%, 0)'
       case 'down':
-        return 'translate3d(0, -50%, 0)'
+        return 'translate3d(0, -30%, 0)'
       case 'left':
-        return 'translate3d(50%, 0, 0)'
+        return 'translate3d(20%, 0, 0)'
       case 'right':
-        return 'translate3d(-50%, 0, 0)'
+        return 'translate3d(-20%, 0, 0)'
+      case 'center':
+        return 'translate3d(0, 0, 0) scale(0.9)'
       default:
         return undefined
     }
   }
 
   const onScroll = useCallback(
-    ([entry]: any) => {
-      const { current }: any = element
-      if (entry.isIntersecting) {
+    ([entry]: IntersectionObserverEntry[]) => {
+      const { current } = element
+      if (current && entry.isIntersecting) {
         current.style.transitionProperty = 'all'
         current.style.transitionDuration = `${duration}s`
         current.style.transitionTimingFunction = 'cubic-bezier(0, 0, 0.2, 1)'
         current.style.transitionDelay = `${delay}s`
-        current.style.opacity = 1
+        current.style.opacity = '1'
         current.style.transform = 'translate3d(0, 0, 0)'
       }
     },
     [delay, duration]
   )
   useEffect(() => {
-    let observer: any
+    let observer: IntersectionObserver
 
     if (element.current) {
       observer = new IntersectionObserver(onScroll, { threshold: 0.3 })

--- a/src/components/common/button/Button/index.tsx
+++ b/src/components/common/button/Button/index.tsx
@@ -5,11 +5,13 @@ import * as S from './style'
 interface Props {
   children: React.ReactNode
   color?: string
-  size?: string
+  size?: Size
   $outline?: boolean
   $fullwidth?: boolean
   [prop: string]: any
 }
+
+export type Size = 'large' | 'medium' | 'small'
 
 export default function Button({ children, color, size, outline, fullwidth, ...props }: Props) {
   return (

--- a/src/components/common/button/Button/index.tsx
+++ b/src/components/common/button/Button/index.tsx
@@ -2,20 +2,27 @@ import React from 'react'
 
 import * as S from './style'
 
-interface Props {
+export interface Props {
   children: React.ReactNode
-  color?: string
-  size?: Size
+  size?: 'large' | 'medium' | 'small'
   $outline?: boolean
   $fullwidth?: boolean
+  $round?: boolean
+  color?: string
   [prop: string]: any
 }
 
-export type Size = 'large' | 'medium' | 'small'
-
-export default function Button({ children, color, size, outline, fullwidth, ...props }: Props) {
+export default function Button({
+  children,
+  size = 'medium',
+  outline = false,
+  fullwidth = false,
+  round = false,
+  color,
+  ...props
+}: Props) {
   return (
-    <S.Button color={color} size={size} $outline={outline} $fullwidth={fullwidth} {...props}>
+    <S.Button $round={round} color={color} size={size} $outline={outline} $fullwidth={fullwidth} {...props}>
       {children}
     </S.Button>
   )
@@ -25,4 +32,5 @@ Button.defaultProps = {
   size: 'medium',
   outline: false,
   fullwidth: false,
+  round: false,
 }

--- a/src/components/common/button/Button/style.ts
+++ b/src/components/common/button/Button/style.ts
@@ -1,5 +1,6 @@
 import styled, { css } from 'styled-components'
 import { darken, lighten } from 'polished'
+import { Size } from '@components/common/button/Button/index'
 
 const colorStyle = css`
   ${({ theme, color }) => {
@@ -27,26 +28,19 @@ const colorStyle = css`
   }}
 `
 const sizes = {
-  large: {
-    height: '3rem',
-    fontSize: '1.25rem',
-  },
-  medium: {
-    height: '2rem',
-    fontSize: '1rem',
-  },
-  small: {
-    height: '1.75rem',
-    fontSize: '0.875rem',
-  },
+  large: css`
+    height: 3rem;
+    font-size: 1.25rem;
+  `,
+  medium: css`
+    height: 2rem;
+    font-size: 1rem;
+  `,
+  small: css`
+    height: 1.75rem;
+    font-size: 0.875rem;
+  `,
 }
-
-const sizeStyles = css`
-  ${({ size }) => css`
-    height: ${sizes[size].height};
-    font-size: ${sizes[size].fontSize};
-  `}
-`
 
 const fullwidthStyle = css`
   ${props =>
@@ -60,7 +54,7 @@ const fullwidthStyle = css`
     `}
 `
 
-export const Button = styled.button<{ size?: string; color?: string; outline?: boolean; fullWidth?: boolean }>`
+export const Button = styled.button<{ size?: Size; color?: string; outline?: boolean; fullWidth?: boolean }>`
   /* 공통 스타일 */
   padding: 0.5rem 1rem;
 
@@ -74,7 +68,7 @@ export const Button = styled.button<{ size?: string; color?: string; outline?: b
 
   cursor: pointer;
   /* 크기 */
-  ${sizeStyles}
+  ${({ size }) => size && sizes[size]}
 
   /* 색상 */
   ${colorStyle}

--- a/src/components/common/button/Button/style.ts
+++ b/src/components/common/button/Button/style.ts
@@ -1,78 +1,80 @@
 import styled, { css } from 'styled-components'
 import { darken, lighten } from 'polished'
-import { Size } from '@components/common/button/Button/index'
+import { Props } from '@components/common/button/Button/index'
 
-const colorStyle = css`
-  ${({ theme, color }) => {
-    const selected = color ?? theme.point
-    return css`
-      background: ${selected};
-      &:hover {
-        background: ${lighten(0.1, selected)};
-      }
-      &:active {
-        background: ${darken(0.1, selected)};
-      }
-      ${props =>
-        props.$outline &&
-        css`
-          color: ${selected};
-          background: none;
-          border: 1px solid ${selected};
-          &:hover {
-            background: ${selected};
-            color: white;
-          }
-        `}
-    `
-  }}
+const backgroundStyle = (selected: string) => css`
+  background: ${selected};
+  &:hover {
+    background: ${darken(0.05, selected)};
+  }
+  &:active,
+  &:focus {
+    background: ${darken(0.15, selected)};
+  }
 `
+
+const outlineStyle = (selected: string) => css`
+  color: ${selected};
+
+  background: ${({ theme }) => theme.basicBg};
+  border: 1px solid ${selected};
+
+  transition: all 0.3s ease-in-out;
+  &:hover {
+    background: ${({ theme }) => theme.basicBg};
+    box-shadow: 0 0 6px 0 ${lighten(0.2, selected)};
+  }
+  &:active,
+  &:focus {
+    color: ${({ theme }) => theme.basicBg};
+
+    background: ${selected};
+    box-shadow: 0 0 6px 0 ${lighten(0.3, selected)};
+  }
+`
+
 const sizes = {
   large: css`
-    height: 3rem;
-    font-size: 1.25rem;
+    padding: 0.8em 1em;
+
+    font-size: 1.066rem;
   `,
   medium: css`
-    height: 2rem;
+    padding: 0.6em 0.8em;
+
     font-size: 1rem;
   `,
   small: css`
-    height: 1.75rem;
+    padding: 0.5em 0.6em;
+
     font-size: 0.875rem;
   `,
 }
 
-const fullwidthStyle = css`
-  ${props =>
-    props.$fullwidth &&
-    css`
-      width: 100%;
-
-      display: flex;
-      justify-content: center;
-      align-items: center;
-    `}
-`
-
-export const Button = styled.button<{ size?: Size; color?: string; outline?: boolean; fullWidth?: boolean }>`
+export const Button = styled.button<Pick<Props, '$round' | 'size' | 'color' | '$outline' | '$fullwidth'>>`
   /* 공통 스타일 */
-  padding: 0.5rem 1rem;
-
+  display: flex;
   justify-content: center;
+  align-items: center;
 
   color: white;
   outline: none;
+  font-weight: normal;
+  line-height: 1.2em;
+
   border: none;
-  border-radius: 6px;
-  font-weight: bold;
 
   cursor: pointer;
+  transition: all 0.2s ease-in-out;
+
   /* 크기 */
-  ${({ size }) => size && sizes[size]}
+  ${({ size }) => sizes[size!]}
 
   /* 색상 */
-  ${colorStyle}
-  
+  ${({ theme, color }) => (color ? backgroundStyle(color) : backgroundStyle(theme.point))}
+  ${({ theme, color, $outline }) => $outline && (color ? outlineStyle(color) : outlineStyle(theme.point))}
+
   /* 기타 */
-  ${fullwidthStyle}
+  border-radius: ${({ $round }) => ($round ? '1.5rem' : '6px')};
+  width: ${({ $fullwidth }) => ($fullwidth ? '100%' : 'auto')};
 `

--- a/src/pages/ComponentsGuide/index.tsx
+++ b/src/pages/ComponentsGuide/index.tsx
@@ -2,14 +2,15 @@ import * as S from './style'
 import ButtonInAlert from '@components/common/button/ButtonInAlert'
 import GuideAlertModal from './modal/GuideAlertModal'
 import GuideAlertModal2 from './modal/GuideAlertModal2'
+import Button from '@components/common/button/Button'
 
 export default function ComponentsGuide() {
   return (
     <S.GuideWrapper>
-      {/* 컴포넌트 가이드 작성 구조 예시 */}
+      {/* 컴포넌트 가이드 작성 구조 예시 START */}
       <S.FolderWrapper>
         <h1>폴더명</h1>
-        😄 이 구조를 복사해서 사용하시면 작성하기 편할겁니다..!
+        컴포넌트 가이드 작성 구조 예시 😄 이 구조를 복사해서 사용하시면 작성하기 편할겁니다..!
         <br />
         바로 이 페이지에서 컴포넌트를 출력해도 되고,
         <br />
@@ -26,9 +27,65 @@ export default function ComponentsGuide() {
           </S.ExampleWrapper>
         </S.ComponentWrapper>
       </S.FolderWrapper>
+      {/* 컴포넌트 가이드 작성 구조 예시 END */}
 
       <S.FolderWrapper>
         <h1>button</h1>
+        <S.ComponentWrapper>
+          <h2>Button</h2>
+          <S.ExampleWrapper>
+            <h3>size= "small" | "meduim" | "large"</h3>
+            <div style={{ display: 'flex', alignItems: 'center', gap: '10px' }}>
+              <Button size="small">작은 버튼</Button>
+              <Button size="medium">중간 버튼(default)</Button>
+              <Button size="large">큰 버튼</Button>
+            </div>
+          </S.ExampleWrapper>
+          <S.ExampleWrapper>
+            <h3>$outline= true | false</h3>
+            <div style={{ display: 'flex', alignItems: 'center', gap: '10px' }}>
+              <Button $outline={false}>기본(false)</Button>
+              <Button $outline={true}>테두리</Button>
+            </div>
+          </S.ExampleWrapper>
+          <S.ExampleWrapper>
+            <h3>$round= true | false</h3>
+            <div style={{ display: 'flex', alignItems: 'center', gap: '10px' }}>
+              <Button $round={false} $outline={true} size="large">
+                기본(false)
+              </Button>
+              <Button $round={true} $outline={true} size="large">
+                동글게
+              </Button>
+            </div>
+          </S.ExampleWrapper>
+          <S.ExampleWrapper>
+            <h3>$fullwidth= true | false</h3>
+            <div>
+              <Button $fullwidth={false} $outline={true} size="large">
+                기본(false)
+              </Button>
+            </div>
+            <div>
+              <Button $fullwidth={true} $outline={true} size="large">
+                설정시
+              </Button>
+            </div>
+          </S.ExampleWrapper>
+          <S.ExampleWrapper>
+            <h3>color= '#E66A77'</h3>
+            <div style={{ display: 'flex', alignItems: 'center', gap: '10px' }}>
+              <Button color="#E66A77">색상 #E66A77</Button>
+              <Button color="#E66A77" $outline={true}>
+                색상 #E66A77
+              </Button>
+              <Button color="#CEDB9E">색상 #CEDB9E</Button>
+              <Button color="#CEDB9E" $outline={true}>
+                색상 #CEDB9E
+              </Button>
+            </div>
+          </S.ExampleWrapper>
+        </S.ComponentWrapper>
         <S.ComponentWrapper>
           <h2>ButtonInAlert</h2>
           <S.ExampleWrapper>

--- a/src/pages/Guide/index.tsx
+++ b/src/pages/Guide/index.tsx
@@ -86,8 +86,8 @@ export default function Guide() {
               <Plus />
               <img src={CalendarLogo} alt="Calendar Logo" />
             </S.LogoDetail>
-            <Button $outline={true} $fullwidth={true} id="round-button" onClick={goToLogin}>
-              트렌더 로그인 하기
+            <Button id="round-button" size="large" $outline={true} $round={true} onClick={goToLogin}>
+              트렌더 시작하기
             </Button>
           </div>
         </div>

--- a/src/pages/Guide/index.tsx
+++ b/src/pages/Guide/index.tsx
@@ -23,56 +23,60 @@ export default function Guide() {
   }
   return (
     <S.GuideContainer>
-      <S.GuideColumnWrapper>
+      <S.GuideColumnWrapper {...useScrollFadeIn<HTMLDivElement>('center', 1, 0.1)}>
         <S.GuideTextHeader style={{ margin: '5.67rem 0 0.75rem 0' }}>
           나의 하루를 한 눈에 보고
           <br /> 간편하게 기록해요
         </S.GuideTextHeader>
         <S.GuideImage $path={Guide1} />
       </S.GuideColumnWrapper>
-      <S.GuideColumnWrapper {...useScrollFadeIn('up', 1, 0.2)}>
+      <S.GuideColumnWrapper {...useScrollFadeIn<HTMLDivElement>('up', 1, 0.1)}>
         <S.GuideTextTitle style={{ margin: '5.73rem 0 1.65rem 0' }}>일정 관리</S.GuideTextTitle>
         <S.GuideText style={{ marginBottom: '1.7rem' }}>
           직관적인 일정 등록으로 시간을 효율적으로 관리해보세요
         </S.GuideText>
         <S.GuideImage $path={Guide2} />
       </S.GuideColumnWrapper>
-      <S.GuideWrapper {...useScrollFadeIn('left', 1, 0.3)}>
-        <S.GuideTextTitle style={{ margin: '5.73rem 0 1.65rem 0', top: 166 }}>루틴 관리</S.GuideTextTitle>
-        <S.GuideText style={{ top: 191 }}>
-          <br />
-          일상 속 작은 목표를 달성해보세요
-          <br /> <br />
-          긍정적인 변화가 하나 둘,
-          <br /> 쌓이는 모습을 즐기며
-          <br /> 더 나은 습관을 만들어보세요.
-        </S.GuideText>
+      <S.GuideWrapper>
+        <div {...useScrollFadeIn<HTMLDivElement>('left', 1, 0.4)}>
+          <S.GuideTextTitle style={{ margin: '5.73rem 0 1.65rem 0', top: 166 }}>루틴 관리</S.GuideTextTitle>
+          <S.GuideText style={{ top: 191 }}>
+            <br />
+            일상 속 작은 목표를 달성해보세요
+            <br /> <br />
+            긍정적인 변화가 하나 둘,
+            <br /> 쌓이는 모습을 즐기며
+            <br /> 더 나은 습관을 만들어보세요.
+          </S.GuideText>
+        </div>
         <S.Stars />
-        <S.FixedLocationImage $path={Routine1} style={{ top: 123, left: 240, width: 314, height: 472 }} />
-        <S.FixedLocationImage $path={Routine2} style={{ top: 193, left: 575, width: 236, height: 472 }} />
+        <S.RoutineImage1 {...useScrollFadeIn<HTMLDivElement>('left', 1, 0.6)} $path={Routine1} />
+        <S.RoutineImage2 {...useScrollFadeIn<HTMLDivElement>('left', 1, 0.8)} $path={Routine2} />
       </S.GuideWrapper>
-      <S.GuideWrapper {...useScrollFadeIn('right', 1, 0.3)}>
-        <S.FixedLocationImage $path={Todo1} style={{ top: 66, left: 31, width: 212, height: 545 }} />
-        <S.FixedLocationImage $path={Todo2} style={{ top: 217, left: 296, width: 212, height: 471 }} />
-        <S.GuideTextTitle style={{ margin: '5.73rem 0 1.65rem 0', top: 193, left: 561 }}>할일 관리</S.GuideTextTitle>
-        <S.GuideText style={{ top: 217, left: 561 }}>
-          <br />
-          루틴과 일정과 함께
-          <br />
-          오늘의 할 일을 빠르게 확인해보세요.
-          <br />
-          <br />
-          또한 주간 목록을 통해
-          <br />
-          일주일을 점검할 수 있어요
-        </S.GuideText>
+      <S.GuideWrapper>
+        <S.ScheduleImage1 {...useScrollFadeIn<HTMLDivElement>('right', 1, 0.2)} $path={Todo1} />
+        <S.ScheduleImage2 {...useScrollFadeIn<HTMLDivElement>('right', 1, 0.3)} $path={Todo2} />
+        <S.ScheduleText {...useScrollFadeIn<HTMLDivElement>('right', 1, 0.5)}>
+          <S.GuideTextTitle>할일 관리</S.GuideTextTitle>
+          <S.GuideText>
+            <br />
+            루틴과 일정과 함께
+            <br />
+            오늘의 할 일을 빠르게 확인해보세요.
+            <br />
+            <br />
+            또한 주간 목록을 통해
+            <br />
+            일주일을 점검할 수 있어요
+          </S.GuideText>
+        </S.ScheduleText>
       </S.GuideWrapper>
-      <S.GuideColumnWrapper {...useScrollFadeIn('up', 1, 0.3)}>
+      <S.GuideColumnWrapper {...useScrollFadeIn<HTMLDivElement>('up', 1, 0.3)}>
         <S.GuideText>마음에 드는 색상을 선택해 나만의 스타일로 TRANDAR를 사용해보세요.</S.GuideText>
         <S.GuideImage $path={StyleGroup} style={{ backgroundSize: 'auto', height: 410 }} />
       </S.GuideColumnWrapper>
       <S.GuideColumnWrapper>
-        <div {...useScrollFadeIn('up', 1, 0.3)}>
+        <div {...useScrollFadeIn<HTMLDivElement>('up', 1, 0.3)}>
           <div style={{ display: 'flex', flexDirection: 'column', justifyContent: 'center', alignItems: 'center' }}>
             <S.GuideTextTitle>
               일상의 모든 기록을 한 곳에서 관리할 수 있는 <span style={{ color: '#4482F9' }}>TRENDAR</span>로

--- a/src/pages/Guide/style.ts
+++ b/src/pages/Guide/style.ts
@@ -3,7 +3,7 @@ import stars from '@/assets/image/guide/stars.png'
 
 export const GuideContainer = styled.div`
   min-width: 60rem;
-  padding: 0px 99px;
+  padding: 0 99px;
 
   display: flex;
   flex-direction: column;
@@ -40,7 +40,6 @@ export const GuideImage = styled.div<{ $path: string }>`
 export const GuideTextHeader = styled.span`
   text-align: center;
 
-  font-family: NanumBarunGothic;
   font-size: 18px;
   font-style: normal;
   font-weight: 400;
@@ -51,7 +50,6 @@ export const GuideTextTitle = styled.span`
   text-align: center;
   position: relative;
 
-  font-family: NanumBarunGothic;
   font-size: 18px;
   font-style: normal;
   font-weight: 600;
@@ -62,7 +60,6 @@ export const GuideText = styled.span`
   text-align: center;
   position: relative;
 
-  font-family: NanumBarunGothic;
   font-size: 15px;
   font-style: normal;
   font-weight: 400;

--- a/src/pages/Guide/style.ts
+++ b/src/pages/Guide/style.ts
@@ -13,7 +13,7 @@ export const GuideContainer = styled.div`
   background: var(--pointBg, #f3f9fa);
 `
 
-export const GuideColumnWrapper = styled.div<any>`
+export const GuideColumnWrapper = styled.div`
   width: 811px;
   height: 800px;
 
@@ -65,7 +65,7 @@ export const GuideText = styled.span`
   font-weight: 400;
   line-height: 180%;
 `
-export const GuideWrapper = styled.div<any>`
+export const GuideWrapper = styled.div`
   width: 811px;
   height: 800px;
 
@@ -79,6 +79,39 @@ export const FixedLocationImage = styled.div<{ $path: string }>`
   background-image: url(${props => props.$path});
   background-repeat: no-repeat;
   background-position: center;
+`
+
+export const RoutineImage1 = styled(FixedLocationImage)`
+  width: 314px;
+  height: 472px;
+  top: 123px;
+  left: 240px;
+`
+export const RoutineImage2 = styled(FixedLocationImage)`
+  width: 236px;
+  height: 472px;
+  top: 193px;
+  left: 575px;
+`
+export const ScheduleImage1 = styled(FixedLocationImage)`
+  width: 212px;
+  height: 545px;
+  top: 66px;
+  left: 31px;
+`
+export const ScheduleImage2 = styled(FixedLocationImage)`
+  width: 212px;
+  height: 471px;
+  top: 217px;
+  left: 296px;
+`
+export const ScheduleText = styled.div`
+  height: 471px;
+  margin: 5.73rem 0 1.65rem 0;
+  top: 193px;
+  left: 561px;
+
+  position: absolute;
 `
 
 export const Stars = styled.div`

--- a/src/pages/Guide/style.ts
+++ b/src/pages/Guide/style.ts
@@ -24,9 +24,6 @@ export const GuideColumnWrapper = styled.div<any>`
 
   #round-button {
     width: 182px;
-    height: 39px;
-
-    border-radius: 22px;
   }
 `
 
@@ -100,7 +97,7 @@ export const Stars = styled.div`
 `
 
 export const LogoDetail = styled.div`
-  padding: 75px 0px 38px 0px;
+  padding: 75px 0 38px 0;
   gap: 31px;
 
   display: inline-flex;

--- a/src/pages/Login/index.tsx
+++ b/src/pages/Login/index.tsx
@@ -27,7 +27,7 @@ export default function Login() {
               <TrendarLogo />
               <TrendarTitle />
             </S.Logo>
-            <Button $outline={true} $fullwidth={true} id="round-button" onClick={goToGuide}>
+            <Button id="round-button" $round={true} size="large" $outline={true} $fullwidth={true} onClick={goToGuide}>
               트렌더 살펴보기
             </Button>
           </S.LogoDiv>

--- a/src/pages/Login/style.ts
+++ b/src/pages/Login/style.ts
@@ -30,7 +30,6 @@ export const LogoDiv = styled.div`
   #slogan {
     color: var(--text, #333);
     text-align: center;
-    font-family: NanumBarunGothic;
     font-size: 18px;
     font-style: normal;
     font-weight: 400;
@@ -38,7 +37,6 @@ export const LogoDiv = styled.div`
   }
   #slogan-bold {
     color: var(--text, #333);
-    font-family: NanumBarunGothic;
     font-size: 18px;
     font-style: normal;
     font-weight: 600;
@@ -59,7 +57,7 @@ export const Logo = styled.div`
 `
 
 export const SocialLogin = styled.div`
-  padding: 36px 0px;
+  padding: 36px 0;
   gap: 24px;
 
   display: flex;
@@ -73,7 +71,6 @@ export const SocialLogin = styled.div`
   #text {
     color: var(--textInfo, #7c7c7c);
     text-align: center;
-    font-family: NanumSquareRound;
     font-size: 15px;
     font-style: normal;
     font-weight: 400;

--- a/src/pages/Login/style.ts
+++ b/src/pages/Login/style.ts
@@ -19,6 +19,7 @@ export const LogoWrapper = styled.div`
   gap: 32px;
 `
 export const LogoDiv = styled.div`
+  width: 100%;
   gap: 18px;
 
   display: flex;
@@ -42,11 +43,6 @@ export const LogoDiv = styled.div`
     font-style: normal;
     font-weight: 600;
     line-height: 180%;
-  }
-  #round-button {
-    height: 39px;
-
-    border-radius: 22px;
   }
 `
 


### PR DESCRIPTION
12월 19일(화)에 코드 한번 살펴봐달라는 부분 보고 수정한것입니다..!
feature/#6 관련 코드라, 해당 브런치로 pr요청합니다

- 버튼 스타일 부분 수정
  - c481d139de3c934f50cb3de3aeb48b952c5f6a67
    - 버튼 사이즈 관련 타입 수정, 각 사이즈에 따른 스타일 적용 방법 수정
    - 개인적으로.. 스타일 작성해둔 `styled`에서 어떤 `props`에 영향받아 어떻게 바뀌는지 한눈에 보였으면 해서 코드를 수정해봤어요.(텍스트로 설명하긴 어려워서 회의때 다시 얘기해볼게요..!)
  - 3c17e6d2bc4b432a7178db441378bc9ac31d7425
    - 위와 같은 이유로 수정했고, 코드 수정하면서 디자인에 맞지 않게 스타일 적용되어있는것 수정했어요
    - `Button` 타이핑을 수정했어요. 컴포넌트에서 사용하는 `props`타입중 일부를 `styled`에서 가져와서 사용하도록 해서, 타입 수정시 이중 수정해줄 필요가 없어질거에요..!

- 5e07e6da042e4a6e49f310bb78aba6e141f3e85d
  - 폰트 중복 적용 제거했어요. 폰트는 상속되기 때문에 실제로 폰트가 적용되고 있지 않는경우 외에는 따로 추가하지 않아도 괜찮아요
 
- e362ed821e2a8d5daada0913d4ff5fe28146fb96
  - `any` 타입을 어떻게 고쳐야하나.. 좀 오래 해매었는데, `제네릭`으로 하면 깔끔하게 되더라구요. 사용시 적절한 타입만 전달해준다면 어디든 사용할 수 있을거에요.
  - guide 페이지에서 각 이미지별로 적용하고 싶다고 하셨는데 잘 안된다고해서 해보니까, `useScrollFadeIn` 훅이 `ref`와 `style`을 반환하고, 그 반환한것을 원하는 컴포넌트에 스프레드하고 싶으셨던거같은데.. 그 컴포넌트에 추가로 `style`코드를 작성해둔 경우, `style`코드가 이중으로 작성되서 뒤 작성한 `style`이 적용되는 바람에 `useScrollFadeIn`에서 반환한 `style`이 적용되지 않아서 `fadeIn`효과가 적용되지 않았던것같아요. 그래서 오성님이 각 컴포넌트를 배치하기위해 추가하셨던 `style`을 styled-components로 작성하여 서로 덮어 씌어지지 않도록 분리하니까 잘 적용되었습니다. 한 번 코드 확인해보셔요